### PR TITLE
Fix asm scratchpad

### DIFF
--- a/ntrclient/Prog/CS/Utility.cs
+++ b/ntrclient/Prog/CS/Utility.cs
@@ -10,8 +10,7 @@ namespace ntrclient.Prog.CS
         public static int RunCommandAndGetOutput(string exeFile, string args, ref string output)
         {
             try
-            { 
-            if (output == null) throw new ArgumentNullException(nameof(output));
+            {
             Process proc = new Process
             {
                 StartInfo = new ProcessStartInfo

--- a/ntrclient/Prog/CS/Utility.cs
+++ b/ntrclient/Prog/CS/Utility.cs
@@ -11,18 +11,18 @@ namespace ntrclient.Prog.CS
         {
             try
             {
-            Process proc = new Process
-            {
-                StartInfo = new ProcessStartInfo
+                Process proc = new Process
                 {
-                    FileName = exeFile,
-                    Arguments = args,
-                    RedirectStandardOutput = true,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardError = true
-                }
-            };
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = exeFile,
+                        Arguments = args,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        RedirectStandardError = true
+                    }
+                };
                 proc.Start();
                 proc.WaitForExit();
                 var processOutput = proc.StandardError.ReadToEnd();
@@ -31,6 +31,11 @@ namespace ntrclient.Prog.CS
                 output = processOutput;
                 proc.Close();
                 return ret;
+            }
+            catch (System.ComponentModel.Win32Exception e) {
+                output = String.Format ("Could not open '{0}'. Make sure it is on your executable path.", exeFile);
+                Console.Error.WriteLine (e);
+                return -1;
             }
             catch (Exception e)
             {

--- a/ntrclient/Prog/Window/AsmEditWindow.cs
+++ b/ntrclient/Prog/Window/AsmEditWindow.cs
@@ -24,7 +24,6 @@ namespace ntrclient.Prog.Window
 
         public static bool CallToolchain(string asOpts, string ldOpts, string ocOpts, ref string result)
         {
-            if (result == null) throw new ArgumentNullException(nameof(result));
             string output = null;
 
             result = "";
@@ -69,11 +68,11 @@ namespace ntrclient.Prog.Window
             ldOpts += " -Ttext 0x" + baseAddr.ToString("X8") + " payload.o";
             ocOpts += " -I elf32-little -O binary a.out payload.bin ";
 
-            string result = "";
+            string result = null;
             bool isSuccessed = CallToolchain(asOpts, ldOpts, ocOpts, ref result);
             if (!isSuccessed)
             {
-                result += "compile failed...";
+                result += "\r\nCompile failed...";
             }
             else
             {

--- a/ntrclient/Prog/Window/AsmEditWindow.cs
+++ b/ntrclient/Prog/Window/AsmEditWindow.cs
@@ -7,9 +7,9 @@ namespace ntrclient.Prog.Window
 {
     public partial class AsmEditWindow : Form
     {
-        private const string AsPath = "bin/arm-none-eabi-as";
-        private const string OcPath = "bin/arm-none-eabi-objcopy";
-        private const string LdPath = "bin/arm-none-eabi-ld";
+        private const string AsPath = "arm-none-eabi-as";
+        private const string OcPath = "arm-none-eabi-objcopy";
+        private const string LdPath = "arm-none-eabi-ld";
         private byte[] _compileResult;
 
         public AsmEditWindow()


### PR DESCRIPTION
- Assume the assembler binaries are directly on the executable path
- Show a descriptive error if the binaries aren't found on the path
- Fix `RunCommandAndGetOutput` always failing due to unnecessary `output == null` check.
